### PR TITLE
Remove unused variable

### DIFF
--- a/lib/moneta/builder.rb
+++ b/lib/moneta/builder.rb
@@ -63,7 +63,7 @@ module Moneta
 
     def new_proxy(klass, *args, &block)
       klass.new(*args, &block)
-    rescue ArgumentError => ex
+    rescue ArgumentError
       check_arity(klass, klass.allocate, args.size)
       raise
     end


### PR DESCRIPTION
The exception was previously being collected into an `ex` variable but was unused.