### PR TITLE
Allow nil options to be passed to LRUHash

### DIFF
--- a/lib/moneta/adapters/lruhash.rb
+++ b/lib/moneta/adapters/lruhash.rb
@@ -15,9 +15,9 @@ module Moneta
       # @option options [Integer] :max_value (options[:max_size]) Maximum byte size of one value, nil disables the limit
       # @option options [Integer] :max_count (10240) Maximum number of values, nil disables the limit
       def initialize(options = {})
-        @max_size = options[:max_size] || 1024000
-        @max_count = options[:max_count] || 10240
-        @max_value = options[:max_value] || @max_size
+        @max_size = options.fetch(:max_size) { 1024000 }
+        @max_count = options.fetch(:max_count) { 10240 }
+        @max_value = options.fetch(:max_value) { @max_size }
         clear
       end
 

--- a/lib/moneta/adapters/lruhash.rb
+++ b/lib/moneta/adapters/lruhash.rb
@@ -10,14 +10,17 @@ module Moneta
       include IncrementSupport
       include CreateSupport
 
+      DEFAULT_MAX_SIZE = 1024000
+      DEFAULT_MAX_COUNT = 10240
+
       # @param [Hash] options
       # @option options [Integer] :max_size (1024000) Maximum byte size of all values, nil disables the limit
       # @option options [Integer] :max_value (options[:max_size]) Maximum byte size of one value, nil disables the limit
       # @option options [Integer] :max_count (10240) Maximum number of values, nil disables the limit
       def initialize(options = {})
-        @max_size = options.fetch(:max_size) { 1024000 }
-        @max_count = options.fetch(:max_count) { 10240 }
-        @max_value = options.fetch(:max_value) { @max_size }
+        @max_size = options.fetch(:max_size) { DEFAULT_MAX_SIZE }
+        @max_count = options.fetch(:max_count) { DEFAULT_MAX_COUNT }
+        @max_value = [options[:max_value], @max_size].compact.min
         clear
       end
 

--- a/script/generate-specs
+++ b/script/generate-specs
@@ -1397,6 +1397,99 @@ it 'deletes oldest' do
     end
     store.key?(i-9).should be_false if i > 9
   end
+end
+
+it 'adds a value that is the same as max_size' do
+  store = Moneta::Adapters::LRUHash.new(max_size: 21)
+  store[:a_key] = 'This is 21 bytes long'
+  store[:a_key].should eq('This is 21 bytes long')
+end
+
+it 'does not add a value that is larger than max_size' do
+  store = Moneta::Adapters::LRUHash.new(max_size: 20)
+  store[:too_long] = 'This is 21 bytes long'
+  store[:too_long].should be_nil
+end
+
+it 'removes an existing key that is replaced by an item that is larger than max_size' do
+  store = Moneta::Adapters::LRUHash.new(max_size: 20)
+  store[:a_key] = 'This will fit'
+  store[:a_key] = 'This is 21 bytes long'
+  store[:a_key].should be_nil
+end
+
+it 'does not add a value that is larger than max_size, when max_value is explicitly missing' do
+  store = Moneta::Adapters::LRUHash.new(max_size: 20, max_value: nil)
+  store[:too_long] = 'This is 21 bytes long'
+  store[:too_long].should be_nil
+end
+
+it 'does not add a value that is larger than max_size, even if max_value is larger than max_size' do
+  store = Moneta::Adapters::LRUHash.new(max_size: 20, max_value: 25)
+  store[:too_long] = 'This is 21 bytes long'
+  store[:too_long].should be_nil
+end
+
+it 'adds a value that is as large as the default max_size when max_size is missing' do
+  store = Moneta::Adapters::LRUHash.new
+  large_item = 'Really big'
+  allow(large_item).to receive(:bytesize).and_return(Moneta::Adapters::LRUHash::DEFAULT_MAX_SIZE)
+  store[:really_big] = large_item
+  store[:really_big].should eq(large_item)
+end
+
+it 'does not add values that are larger than the default max_size when max_size is missing' do
+  store = Moneta::Adapters::LRUHash.new
+  large_item = 'Really big'
+  allow(large_item).to receive(:bytesize).and_return(Moneta::Adapters::LRUHash::DEFAULT_MAX_SIZE + 1)
+  store[:really_big] = large_item
+  store[:really_big].should be_nil
+end
+
+it 'adds values that are larger than the default max_size when max_size is nil' do
+  store = Moneta::Adapters::LRUHash.new(max_size: nil)
+  large_item = 'Really big'
+  allow(large_item).to receive(:bytesize).and_return(Moneta::Adapters::LRUHash::DEFAULT_MAX_SIZE + 1)
+  store[:really_big] = large_item
+  store[:really_big].should eq(large_item)
+end
+
+it 'adds an individual value that is equal to max_value' do
+  store = Moneta::Adapters::LRUHash.new(max_value: 13)
+  store[:a_key] = '13 bytes long'
+  store[:a_key].should eq('13 bytes long')
+end
+
+it 'does not add a value that is larger than max_value' do
+  store = Moneta::Adapters::LRUHash.new(max_value: 20)
+  store[:too_long] = 'This is 21 bytes long'
+  store[:too_long].should be_nil
+end
+
+it 'removes keys that are replaced by values larger than max_value' do
+  store = Moneta::Adapters::LRUHash.new(max_value: 20)
+  store[:too_long] = 'This will fit'
+  store[:too_long] = 'This is 21 bytes long'
+  store[:too_long].should be_nil
+end
+
+it 'only allows the default number of items when max_count is missing' do
+  stub_const('Moneta::Adapters::LRUHash::DEFAULT_MAX_COUNT', 5)
+  store = Moneta::Adapters::LRUHash.new(max_value: nil, max_size: nil)
+  (1..6).each { |n| store[n] = n }
+  store.key?(1).should be_false
+  store[1].should be_nil
+  store[2].should eq(2)
+  store[6].should eq(6)
+end
+
+it 'adds more values than DEFAULT_MAX_COUNT allows when max_count is nil' do
+  stub_const('Moneta::Adapters::LRUHash::DEFAULT_MAX_COUNT', 5)
+  store = Moneta::Adapters::LRUHash.new(max_count: nil, max_value: nil, max_size: nil)
+  (1..6).each { |n| store[n] = n }
+  store[1].should eq(1)
+  store[2].should eq(2)
+  store[6].should eq(6)
 end}
   },
   'adapter_mongo' => {

--- a/spec/moneta/adapter_lruhash_spec.rb
+++ b/spec/moneta/adapter_lruhash_spec.rb
@@ -40,4 +40,97 @@ describe_moneta "adapter_lruhash" do
       store.key?(i-9).should be_false if i > 9
     end
   end
+
+  it 'adds a value that is the same as max_size' do
+    store = Moneta::Adapters::LRUHash.new(max_size: 21)
+    store[:a_key] = 'This is 21 bytes long'
+    store[:a_key].should eq('This is 21 bytes long')
+  end
+
+  it 'does not add a value that is larger than max_size' do
+    store = Moneta::Adapters::LRUHash.new(max_size: 20)
+    store[:too_long] = 'This is 21 bytes long'
+    store[:too_long].should be_nil
+  end
+
+  it 'removes an existing key that is replaced by an item that is larger than max_size' do
+    store = Moneta::Adapters::LRUHash.new(max_size: 20)
+    store[:a_key] = 'This will fit'
+    store[:a_key] = 'This is 21 bytes long'
+    store[:a_key].should be_nil
+  end
+
+  it 'does not add a value that is larger than max_size, when max_value is explicitly missing' do
+    store = Moneta::Adapters::LRUHash.new(max_size: 20, max_value: nil)
+    store[:too_long] = 'This is 21 bytes long'
+    store[:too_long].should be_nil
+  end
+
+  it 'does not add a value that is larger than max_size, even if max_value is larger than max_size' do
+    store = Moneta::Adapters::LRUHash.new(max_size: 20, max_value: 25)
+    store[:too_long] = 'This is 21 bytes long'
+    store[:too_long].should be_nil
+  end
+
+  it 'adds a value that is as large as the default max_size when max_size is missing' do
+    store = Moneta::Adapters::LRUHash.new
+    large_item = 'Really big'
+    allow(large_item).to receive(:bytesize).and_return(Moneta::Adapters::LRUHash::DEFAULT_MAX_SIZE)
+    store[:really_big] = large_item
+    store[:really_big].should eq(large_item)
+  end
+
+  it 'does not add values that are larger than the default max_size when max_size is missing' do
+    store = Moneta::Adapters::LRUHash.new
+    large_item = 'Really big'
+    allow(large_item).to receive(:bytesize).and_return(Moneta::Adapters::LRUHash::DEFAULT_MAX_SIZE + 1)
+    store[:really_big] = large_item
+    store[:really_big].should be_nil
+  end
+
+  it 'adds values that are larger than the default max_size when max_size is nil' do
+    store = Moneta::Adapters::LRUHash.new(max_size: nil)
+    large_item = 'Really big'
+    allow(large_item).to receive(:bytesize).and_return(Moneta::Adapters::LRUHash::DEFAULT_MAX_SIZE + 1)
+    store[:really_big] = large_item
+    store[:really_big].should eq(large_item)
+  end
+
+  it 'adds an individual value that is equal to max_value' do
+    store = Moneta::Adapters::LRUHash.new(max_value: 13)
+    store[:a_key] = '13 bytes long'
+    store[:a_key].should eq('13 bytes long')
+  end
+
+  it 'does not add a value that is larger than max_value' do
+    store = Moneta::Adapters::LRUHash.new(max_value: 20)
+    store[:too_long] = 'This is 21 bytes long'
+    store[:too_long].should be_nil
+  end
+
+  it 'removes keys that are replaced by values larger than max_value' do
+    store = Moneta::Adapters::LRUHash.new(max_value: 20)
+    store[:too_long] = 'This will fit'
+    store[:too_long] = 'This is 21 bytes long'
+    store[:too_long].should be_nil
+  end
+
+  it 'only allows the default number of items when max_count is missing' do
+    stub_const('Moneta::Adapters::LRUHash::DEFAULT_MAX_COUNT', 5)
+    store = Moneta::Adapters::LRUHash.new(max_value: nil, max_size: nil)
+    (1..6).each { |n| store[n] = n }
+    store.key?(1).should be_false
+    store[1].should be_nil
+    store[2].should eq(2)
+    store[6].should eq(6)
+  end
+
+  it 'adds more values than DEFAULT_MAX_COUNT allows when max_count is nil' do
+    stub_const('Moneta::Adapters::LRUHash::DEFAULT_MAX_COUNT', 5)
+    store = Moneta::Adapters::LRUHash.new(max_count: nil, max_value: nil, max_size: nil)
+    (1..6).each { |n| store[n] = n }
+    store[1].should eq(1)
+    store[2].should eq(2)
+    store[6].should eq(6)
+  end
 end


### PR DESCRIPTION
The change to allow `nil` to be passed to `LRUHash` was implemented in such a way that if `nil` was passed, the default values would still be used. This uses `fetch` so that the default values will only be used if the options aren't passed.