### PR TITLE
delete expires_in option for cache read_entry

### DIFF
--- a/lib/active_support/cache/moneta_store.rb
+++ b/lib/active_support/cache/moneta_store.rb
@@ -33,6 +33,7 @@ module ActiveSupport
       protected
 
       def read_entry(key, options)
+        options.delete(:expires_in)
         entry = @store.load(key, moneta_options(options))
         entry && (ActiveSupport::Cache::Entry === entry ? entry : ActiveSupport::Cache::Entry.new(entry))
       end


### PR DESCRIPTION
see #89 for detail. Besides, rails memory/file cache store and redis store won't set the expires when calling read_entry