### PR TITLE
Fix Rack::Cache require paths

### DIFF
--- a/lib/rack/cache/moneta.rb
+++ b/lib/rack/cache/moneta.rb
@@ -1,7 +1,7 @@
 require 'moneta'
 require 'rack/cache/key'
-require 'rack/cache/metastore'
-require 'rack/cache/entitystore'
+require 'rack/cache/meta_store'
+require 'rack/cache/entity_store'
 
 module Rack
   module Cache


### PR DESCRIPTION
Rack::Cache 1.6.0 renamed a few files and now issues warnings when the old filenames are required.  This patch tries to load the new file paths first, and falls back to the old file paths in order to retain compatibility with Rack::Cache < 1.6.0