### PR TITLE
Fix RSpec deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 gemspec
 
 # Testing
-gem 'rspec'
-gem 'rspec-retry'
+gem 'rspec', '~> 2.0'
+gem 'rspec-retry', '0.4.4' # 0.4.5 does not work with rspec 2
 
 # Serializer used by Transformer
 gem 'tnetstring'


### PR DESCRIPTION
This should get Travis CI to go again, but lots of tests still fail.

Moneta's specs are largely incompatible with RSpec 3.  Additionally, rspec-retry 0.4.5 is not compatible with RSpec 2.  See https://github.com/NoRedInk/rspec-retry/issues/53