### PR TITLE
Force mysql2 0.3.x in bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'jruby-memcached', platforms: :jruby
 gem 'sqlite3', platforms: :ruby
 gem 'activerecord-jdbc-adapter', platforms: :jruby
 gem 'activerecord-jdbcmysql-adapter', platforms: :jruby
-gem 'mysql2', '>= 0.3.12b5', platforms: :ruby
+gem 'mysql2', '~> 0.3.12b5', platforms: :ruby
 # gdbm for jruby needs ffi
 gem 'ffi', platforms: :jruby
 gem 'gdbm', platforms: :jruby


### PR DESCRIPTION
This is needed because ActiveRecord 4 requires mysql2 '~> 0.3.10', which causes tests to fail.