### PR TITLE
Update bundler in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ services:
   - memcached
   - mongodb
 before_install:
+  - gem install bundler -v '~> 1.10'
   #- script/install-kyotocabinet
   - sudo apt-get install -qq libtokyocabinet8 libtokyocabinet-dev liblzo2-dev libtdb-dev libleveldb-dev tokyotyrant
   - script/start-services


### PR DESCRIPTION
This is apparently needed because some rubies are using an old, buggy
bundler by default.  Contributes to #103 