### PR TITLE
dup options in MonetaStore#moneta_options

### DIFF
--- a/lib/active_support/cache/moneta_store.rb
+++ b/lib/active_support/cache/moneta_store.rb
@@ -50,9 +50,9 @@ module ActiveSupport
       private
 
       def moneta_options(options)
-        options ||= {}
-        options[:expires] = options.delete(:expires_in).to_i if options.include?(:expires_in)
-        options
+        new_options = options ? options.dup : {}
+        new_options[:expires] = new_options.delete(:expires_in).to_i if new_options.include?(:expires_in)
+        new_options
       end
     end
   end

--- a/spec/active_support/cache_moneta_store_spec.rb
+++ b/spec/active_support/cache_moneta_store_spec.rb
@@ -60,6 +60,13 @@ describe ActiveSupport::Cache::MonetaStore do
     @store.fetch('rabbit').should be_nil
   end
 
+  it 'fetches data with expiration time' do
+    @store.fetch('rabbit', expires_in: 1.second) { @white_rabbit }
+    @store.fetch('rabbit').should == @white_rabbit
+    sleep 2
+    @store.fetch('rabbit').should be_nil
+  end
+
   it 'reads multiple keys' do
     @store.write 'irish whisky', 'Jameson'
     result = @store.read_multi 'rabbit', 'irish whisky'
@@ -194,4 +201,3 @@ describe ActiveSupport::Cache::MonetaStore do
     ActiveSupport::Cache::MonetaStore.instrument = false
   end
 end
-


### PR DESCRIPTION
We should not change options in read_entry, which will be passed to write-cache method.

see #89, but some description of 89 is wrong. The root cause is `expires_in` is deleted in `read_entry`, so cache will never expire. So the solution in #90 is wrong.
