### PR TITLE
activerecord: use connection to check if table exists

### DIFF
--- a/lib/moneta/adapters/activerecord.rb
+++ b/lib/moneta/adapters/activerecord.rb
@@ -59,7 +59,7 @@ module Moneta
           end
 
           table.connection_pool.with_connection do |conn|
-            unless table.table_exists?
+            unless conn.table_exists?(table.table_name)
               conn.create_table(table.table_name, id: false) do |t|
                 # Do not use binary key (Issue #17)
                 t.string :k, null: false


### PR DESCRIPTION
Using `table.table_exists?` seems to fail in some cases (perhaps a race
condition); whereas `conn.table_exists?(table_name)` does not.

This should not affect performance, as the `create` method is only
called once when initializing an activerecord class.