### PR TITLE
Fix race in Pool#pop.

### DIFF
--- a/lib/moneta/pool.rb
+++ b/lib/moneta/pool.rb
@@ -48,13 +48,11 @@ module Moneta
     end
 
     def pop
-      if @mutex.synchronize { @pool.empty? }
+      unless store = @mutex.synchronize { @pool.pop }
         store = @builder.build.last
         @mutex.synchronize { @all << store }
-        store
-      else
-        @mutex.synchronize { @pool.pop }
       end
+      store
     end
   end
 end


### PR DESCRIPTION
There was a race in the Pool#pop method, between testing the `@pool.empty?` and actually popping the value with `@pool.pop`. For example, if there were two contenders and only one store in the pool, one of the contenders could end with a `nil` store. The fix is to do the pop atomically, so there is no race possible.